### PR TITLE
Slight API change

### DIFF
--- a/src/main/scala/com/github/verbalexpressions/VerbalExpression.scala
+++ b/src/main/scala/com/github/verbalexpressions/VerbalExpression.scala
@@ -33,8 +33,13 @@ final case class VerbalExpression(prefix: String = "", expression: String = "", 
   def any = anyOf _
 
   def lineBreak = add("(\\n|(\\r\\n))")
-  def startOfLine(enable: Boolean = true) = copy(prefix = if (enable) "^" else "")
-  def endOfLine(enable: Boolean = true) = copy(suffix = if (enable) "$" else "")
+  def mustStartLine() = startOfLine()
+  def lineStartNotMandatory() = startOfLine(false)
+  private[verbalexpressions] def startOfLine(enable: Boolean = true) = copy(prefix = if (enable) "^" else "")
+
+  def mustEndLine() = endOfLine()
+  def endOfLineNotMandatory() = endOfLine(false)
+  private[verbalexpressions] def endOfLine(enable: Boolean = true) = copy(suffix = if (enable) "$" else "")
 
   def or(value: StringOrVerbalExp) = copy("(" + prefix, expression + ")|(" + value, ")" + suffix)
 

--- a/src/main/scala/com/github/verbalexpressions/VerbalExpression.scala
+++ b/src/main/scala/com/github/verbalexpressions/VerbalExpression.scala
@@ -3,9 +3,9 @@ package com.github.verbalexpressions
 import java.util.regex.Pattern
 import com.github.verbalexpressions.VerbalExpression._
 
-case class VerbalExpression(prefix: String = "", expression: String = "", suffix: String = "", modifiers: Int = 0) {
+final case class VerbalExpression(prefix: String = "", expression: String = "", suffix: String = "", modifiers: Int = 0) {
 
-  def add(value: String) = copy(expression = expression + value)
+  private[verbalexpressions] def add(value: String) = copy(expression = expression + value)
 
   def andThen(value: StringOrVerbalExp) = add(s"($value)")
   def `then` = andThen _

--- a/src/test/scala/com/github/verbalexpressions/VerbalExpressionSpec.scala
+++ b/src/test/scala/com/github/verbalexpressions/VerbalExpressionSpec.scala
@@ -55,6 +55,16 @@ final class VerbalExpressionSpec extends Specification {
         .startOfLine(false)
         .toString mustEqual "expr"
     }
+
+    "be turned on with 'mustStartLine'" in {
+      VerbalExpression().mustStartLine().toString mustEqual "^"
+    }
+
+    "be turned off with 'lineStartNotMandatory'" in {
+      VerbalExpression("^", "expr")
+        .lineStartNotMandatory()
+        .toString mustEqual "expr"
+    }
   }
 
   "endOfLine" should {


### PR DESCRIPTION
Hi,
This suggest what i think can be an API improvement.

1. The `VerbalExpression` case class becomes final - a simple "safety" best practice and shows the intention of this not being extended.
2. The `add` method becomes private. I saw it used only internally, and figured it's not intended to be an API, since it basically kind of exposes implementation detail, and might be dangerous to expose as an API (it receives the string to concatenate).
Note that it's still available for tests.
3. The start and end of line - instead of having a single API method with boolean parameter - have more explicit methods that wrap those single method and provide a more explicit expression of the intent.

Let me know what you think.
